### PR TITLE
Handle packages without download statistics.

### DIFF
--- a/public/charts.js
+++ b/public/charts.js
@@ -159,9 +159,11 @@ function sanitizeData(json) {
   var data = json.downloads;
 
   var date = null;
-  for (var i = 0; i < data.length; i++) {
-    date = data[i].day;
-    result[date] = data[i].downloads;
+  if (data) {
+    for (var i = 0; i < data.length; i++) {
+      date = data[i].day;
+      result[date] = data[i].downloads;
+    }
   }
 
   return result;

--- a/src/charts.js
+++ b/src/charts.js
@@ -158,9 +158,11 @@ function sanitizeData(json) {
   var data = json.downloads;
 
   var date = null;
-  for (var i = 0; i < data.length; i++) {
-    date = data[i].day;
-    result[date] = data[i].downloads;
+  if (data) {
+    for (var i = 0; i < data.length; i++) {
+      date = data[i].day;
+      result[date] = data[i].downloads;
+    }
   }
 
   return result;


### PR DESCRIPTION
Modules less than a day old would previously throw an error, breaking the download/display of author graphs if they had published a package recently.

Thanks! :)
