### PR TITLE
Correctly sort projects by total

### DIFF
--- a/src/charts.js
+++ b/src/charts.js
@@ -390,7 +390,7 @@ function showAuthorStats(author, from, to) {
           $('#loading').remove();
 
           totals = totals.sort(function(a,b) {
-            return b.count - a.count;
+            return b.count.replace(/,/g, '') - a.count.replace(/,/g, '');
           });
 
           $('#pkgs').append('<h3>Packages by '+author+'</h3><ul></ul>');


### PR DESCRIPTION
The value of the `count` property seems to be a formatted string. The sorting doesn't work for strings like `"1,001"` since those are converted to `NaN`. Replacing `,` should fix it.