### PR TITLE
Use GZIPped Assets

### DIFF
--- a/public/charts.html
+++ b/public/charts.html
@@ -67,8 +67,8 @@
       <p>© 2012–2014 – Paul Vorbach. <a
         href="http://paul.vorba.ch/">Contact</a>.</p>
     </footer>
-    <script type="text/javascript" src="jquery.js"></script>
-    <script type="text/javascript" src="highcharts.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/3.0.10/highcharts.js"></script>
     <script type="text/javascript" src="charts.js"></script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Pulling jquery.js and highcharts.js from cdnjs.com so they will be GZIPped. I used the same version already being used.

Current file sizes for charts.html:

* jQuery:        237KB
* highcharts:  146KB

Download sizes if this PR is merged:

* jQuery:        29.2KB
* highcharts:  54.3KB

That's a download size decrease of 299.5KB. That should drop charts.html from about 425KB to about 126.5KB (before stats data is downloaded, but that's a small donwload).