### PR TITLE
feat: add opensearch

### DIFF
--- a/public/charts.html
+++ b/public/charts.html
@@ -8,6 +8,7 @@
     <meta name="author" content="Paul Vorbach">
     <meta name="keywords" content="npm, node.js, statistics, chart, downloads">
     <meta name="description" content="download statistics for npm packages">
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="npm-stat.com">
 </head>
 <body>
     <nav id="nav">

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <meta name="author" content="Paul Vorbach">
     <meta name="keywords" content="npm, node.js, statistics, chart, downloads">
     <meta name="description" content="download statistics for NPM packages">
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="npm-stat.com">
 </head>
 <body>
     <nav id="nav">

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,7 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>npm-stat.com</ShortName>
+  <Description>Package Search</Description>
+  <Url type="text/html" method="get" template="https://npm-stat.com/charts.html?package={searchTerms}"/>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image height="16" width="16" type="image/vnd.microsoft.icon">https://npm-stat.com/favicon.ico</Image>
+</OpenSearchDescription>


### PR DESCRIPTION
With opensearch, people could directly use the browser search-engine bar to search `npm-stat.com`, without having to load the landing page and then type their search.

Relevant:
[home and spec for opensearch](http://www.opensearch.org)