### PR TITLE
Add `viewport` meta

### DIFF
--- a/src/main/resources/static/charts.html
+++ b/src/main/resources/static/charts.html
@@ -8,6 +8,7 @@
     <meta name="author" content="Paul Vorbach">
     <meta name="keywords" content="npm, node.js, statistics, chart, downloads">
     <meta name="description" content="download statistics for npm packages">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="npm-stat.com">
 </head>
 <body>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -8,6 +8,7 @@
     <meta name="author" content="Paul Vorbach">
     <meta name="keywords" content="npm, node.js, statistics, chart, downloads">
     <meta name="description" content="download statistics for NPM packages">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="npm-stat.com">
 </head>
 <body>


### PR DESCRIPTION
I'm personally use npm-stat.com from mobile most of the times. And it's pain to have to zoom it all the time.

This tag will make npm-stat.com adopt to device width.