### PR TITLE
Remove blank package names from query

### DIFF
--- a/src/main/js/charts.js
+++ b/src/main/js/charts.js
@@ -478,7 +478,7 @@ window.submitForm = function submitForm() {
 
     if ($nameType.val() === 'package') {
         var packageNames = $('input[name=package]').val().split(',').filter(function (packageName) {
-          return packageName.length > 0;
+          return packageName.trim().length > 0;
         });
 
         if (packageNames.length >= 1 && packageNames[0].trim() !== '') {

--- a/src/main/js/charts.js
+++ b/src/main/js/charts.js
@@ -477,7 +477,9 @@ window.submitForm = function submitForm() {
     var formData = {};
 
     if ($nameType.val() === 'package') {
-        var packageNames = $('input[name=package]').val().split(',');
+        var packageNames = $('input[name=package]').val().split(',').filter(function (packageName) {
+          return packageName.length > 0;
+        });
 
         if (packageNames.length >= 1 && packageNames[0].trim() !== '') {
             formData['package'] = $.map(packageNames, function (packageName) {


### PR DESCRIPTION
Including extra commas or whitespace in place of a package name results in a chart called "Series 1" which reports 536,513,973 downloads on 31 August, 2019.