### PR TITLE
Fix README to use the latest links of npm and npm-stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 npm-stat
 ========
 
-download statistics for [npm](https://npmjs.org/) packages
+Download statistics for [npm](https://npmjs.com/) packages.
 
 Examples
 --------
 
-  * My most frequently downloaded package: [clone](http://npm-stat.vorba.ch/charts.html?package=clone)
-  * The most depended-upon package: [lodash](http://npm-stat.vorba.ch/charts.html?package=lodash)
+  * My most frequently downloaded package: [clone](http://npm-stat.com/charts.html?package=clone)
+  * The most depended-upon package: [lodash](http://npm-stat.com/charts.html?package=lodash)
 
 [![](https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=C7CB62H9VAFX6&source=url)


### PR DESCRIPTION
Currently all links on README goes to a 404 not found page. This PR fixes that. Also change npmjs.org to npmjs.com.