### PR TITLE
changed 2019 to 2025

### DIFF
--- a/src/main/java/de/vorb/npmstat/clients/authors/PackageDetailsJson.java
+++ b/src/main/java/de/vorb/npmstat/clients/authors/PackageDetailsJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/resources/static/charts.html
+++ b/src/main/resources/static/charts.html
@@ -74,7 +74,7 @@
         </footer>
     </section>
     <footer id="about">
-        <p>&copy; 2012&ndash;2019 &ndash; Paul Vorbach. <a href="https://paul.vorba.ch/">Contact</a>.</p>
+        <p>&copy; 2012&ndash;2025 &ndash; Paul Vorbach. <a href="https://paul.vorba.ch/">Contact</a>.</p>
     </footer>
     <script type="text/javascript" src="jquery-2.0.3.min.js"></script>
     <script type="text/javascript" src="highcharts-3.0.10.min.js"></script>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -75,7 +75,7 @@
         </footer>
     </section>
     <footer id="about">
-        <p>&copy; 2012&ndash;2019 &ndash; Paul Vorbach. <a href="https://paul.vorba.ch/">Contact</a>.</p>
+        <p>&copy; 2012&ndash;2025 &ndash; Paul Vorbach. <a href="https://paul.vorba.ch/">Contact</a>.</p>
     </footer>
     <script type="text/javascript" src="jquery-2.0.3.min.js"></script>
     <script type="text/javascript" src="highcharts-3.0.10.min.js"></script>


### PR DESCRIPTION
Updated the copyright year in the project from **2012–2019** to **2012–2025** to reflect the latest contributions and current year.

**Changes:**

* Modified all instances of `2012–2019` to `2012–2025` in source files and documentation.

No functional changes were made; this is purely a documentation update.